### PR TITLE
Set as data structure to test for duplicates instead of a sparse matrix

### DIFF
--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -541,7 +541,8 @@ def main(args=None):
     chrom_sizes = get_chrom_sizes(str1)
     # initialize read start positions matrix
     # read_pos_matrix = ReadPositionMatrix(chrom_sizes)
-    read_pos_matrix = ReadPositionMatrix()
+    if args.skipDuplicationCheck is False:
+        read_pos_matrix = ReadPositionMatrix()
 
     # define bins
     rf_positions = None
@@ -680,13 +681,13 @@ def main(args=None):
             one_mate_low_quality += 1
             continue
 
-        # if args.skipDuplicationCheck is False:
-        #     if read_pos_matrix.is_duplicated(ref_id2name[mate1.rname],
-        #                                      mate1.pos,
-        #                                      ref_id2name[mate2.rname],
-        #                                      mate2.pos):
-        #         duplicated_pairs += 1
-        #         continue
+        if args.skipDuplicationCheck is False:
+            if read_pos_matrix.is_duplicated(ref_id2name[mate1.rname],
+                                             mate1.pos,
+                                             ref_id2name[mate2.rname],
+                                             mate2.pos):
+                duplicated_pairs += 1
+                continue
 
         # check if reads belong to a bin
         mate_bins = []

--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 import numpy as np
-from scipy.sparse import coo_matrix, dia_matrix, dok_matrix
+from scipy.sparse import coo_matrix, dia_matrix
 import time
 from os import unlink
 import pysam
@@ -18,29 +18,11 @@ debug = 1
 
 class ReadPositionMatrix(object):
     """ class to check for PCR duplicates.
-    A sparse matrix having as bins all possible
-    start sites (single bp resolution)
-    is created. PCR duplicates
-    are determined by checking if the matrix
-    cell is already filled.
-
+    A set with all seen reads is used to check for duplicates.
     """
 
     def __init__(self):
         """
-        >>> rp = ReadPositionMatrix([('1', 10), ('2', 10)])
-        >>> rp.pos2matrix_bin('1', 0)
-        0
-        >>> rp.pos2matrix_bin('2', 0)
-        10
-        >>> rp.is_duplicated('1', 0, '2', 0)
-        False
-        >>> rp.pos_matrix[0,10]
-        True
-        >>> rp.pos_matrix[10,0]
-        True
-        >>> rp.is_duplicated('1', 0, '2', 0)
-        True
         """
         self.pos_matrix = set()
 
@@ -53,11 +35,6 @@ class ReadPositionMatrix(object):
             self.pos_matrix.add(id_string)
             self.pos_matrix.add("%s%s-%s%s" % (chrom2, start2, chrom1, start1))
 
-    def pos2matrix_bin(self, chrom, start):
-        return self.chr_start_pos[chrom] + start
-
-    def add_matrix(self, pReadPosMatrix):
-        self.pos_matrix += pReadPosMatrix.pos_matrix
 
 
 def parse_arguments(args=None):
@@ -540,7 +517,6 @@ def main(args=None):
 
     chrom_sizes = get_chrom_sizes(str1)
     # initialize read start positions matrix
-    # read_pos_matrix = ReadPositionMatrix(chrom_sizes)
     if args.skipDuplicationCheck is False:
         read_pos_matrix = ReadPositionMatrix()
 

--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -23,6 +23,11 @@ class ReadPositionMatrix(object):
 
     def __init__(self):
         """
+        >>> rp = ReadPositionMatrix()
+        >>> rp.is_duplicated('1', 0, '2', 0)
+        False
+        >>> rp.is_duplicated('1', 0, '2', 0)
+        True
         """
         self.pos_matrix = set()
 

--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -36,7 +36,6 @@ class ReadPositionMatrix(object):
             self.pos_matrix.add("%s%s-%s%s" % (chrom2, start2, chrom1, start1))
 
 
-
 def parse_arguments(args=None):
 
     parser = argparse.ArgumentParser(

--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -26,7 +26,7 @@ class ReadPositionMatrix(object):
 
     """
 
-    def __init__(self, chrom_sizes):
+    def __init__(self):
         """
         >>> rp = ReadPositionMatrix([('1', 10), ('2', 10)])
         >>> rp.pos2matrix_bin('1', 0)
@@ -42,27 +42,22 @@ class ReadPositionMatrix(object):
         >>> rp.is_duplicated('1', 0, '2', 0)
         True
         """
-        # determine number of bins
-        total_size = 0
-        self.chr_start_pos = {}
-        for chrom, size in chrom_sizes:
-            self.chr_start_pos[chrom] = total_size
-            total_size += size
-
-        self.pos_matrix = dok_matrix((total_size, total_size), dtype=bool)
+        self.pos_matrix = set()
 
     def is_duplicated(self, chrom1, start1, chrom2, start2):
-        pos1 = self.pos2matrix_bin(chrom1, start1)
-        pos2 = self.pos2matrix_bin(chrom2, start2)
-        if self.pos_matrix[pos1, pos2] == 1:
+
+        id_string = "%s%s-%s%s" % (chrom1, start1, chrom2, start2)
+        if id_string in self.pos_matrix:
             return True
         else:
-            self.pos_matrix[pos1, pos2] = 1
-            self.pos_matrix[pos2, pos1] = 1
-            return False
+            self.pos_matrix.add(id_string)
+            self.pos_matrix.add("%s%s-%s%s" % (chrom2, start2, chrom1, start1))
 
     def pos2matrix_bin(self, chrom, start):
         return self.chr_start_pos[chrom] + start
+
+    def add_matrix(self, pReadPosMatrix):
+        self.pos_matrix += pReadPosMatrix.pos_matrix
 
 
 def parse_arguments(args=None):
@@ -545,7 +540,8 @@ def main(args=None):
 
     chrom_sizes = get_chrom_sizes(str1)
     # initialize read start positions matrix
-    read_pos_matrix = ReadPositionMatrix(chrom_sizes)
+    # read_pos_matrix = ReadPositionMatrix(chrom_sizes)
+    read_pos_matrix = ReadPositionMatrix()
 
     # define bins
     rf_positions = None

--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -39,6 +39,7 @@ class ReadPositionMatrix(object):
         else:
             self.pos_matrix.add(id_string)
             self.pos_matrix.add("%s%s-%s%s" % (chrom2, start2, chrom1, start1))
+            return False
 
 
 def parse_arguments(args=None):

--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -680,13 +680,13 @@ def main(args=None):
             one_mate_low_quality += 1
             continue
 
-        if args.skipDuplicationCheck is False:
-            if read_pos_matrix.is_duplicated(ref_id2name[mate1.rname],
-                                             mate1.pos,
-                                             ref_id2name[mate2.rname],
-                                             mate2.pos):
-                duplicated_pairs += 1
-                continue
+        # if args.skipDuplicationCheck is False:
+        #     if read_pos_matrix.is_duplicated(ref_id2name[mate1.rname],
+        #                                      mate1.pos,
+        #                                      ref_id2name[mate2.rname],
+        #                                      mate2.pos):
+        #         duplicated_pairs += 1
+        #         continue
 
         # check if reads belong to a bin
         mate_bins = []


### PR DESCRIPTION
To check for duplicates a set is used instead of a sparse matrix. Tested with ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR195/007/SRR1956527/SRR1956527_2.fastq.gz
ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR195/007/SRR1956527/SRR1956527_1.fastq.gz
and a bin size of 10000. Run time was around 1/3 faster and memory usage was 2 GB less.