### PR TITLE
Fixing potential bugs in fdr

### DIFF
--- a/hicexplorer/hicFindTADs.py
+++ b/hicexplorer/hicFindTADs.py
@@ -914,10 +914,10 @@ class HicFindTads(object):
             if self.correct_for_multiple_testing == 'fdr':
                 if delta_of_min[idx] >= self.delta and idx in pvalue_of_min and pvalue_of_min[idx] <= self.pvalueFDR:
                     filtered_min_idx += [idx]
-            if self.correct_for_multiple_testing == 'bonferroni':
-                if delta_of_min[idx] >= self.delta and pvalue_of_min[idx] <= self.threshold_comparisons:
+            elif self.correct_for_multiple_testing == 'bonferroni':
+                if delta_of_min[idx] >= self.delta and idx in pvalue_of_min and pvalue_of_min[idx] <= self.threshold_comparisons:
                     filtered_min_idx += [idx]
-            elif self.correct_for_multiple_testing == 'None':
+            else:
                 if delta_of_min[idx] >= self.delta:
                     filtered_min_idx += [idx]
         if self.correct_for_multiple_testing == 'fdr':


### PR DESCRIPTION
This PR fixes a potential bug by checking now the member ship of `idx` in `pvalue_of_min` before accessing `pvalue_of_min[idx]`. Additional the computation of fdr was changed from `<` comparison to `<=`. 
The more restrictive behaviour of hic's fdr in comparison to R-fdr is caused by the membership test of `idx` in `delta_of_min` and the subsequent test `delte_of_min[idx] >= self.delta`. (Line 912 and 915)