### PR TITLE
Fix for bug: hicPlotMatrix with --log parameter

### DIFF
--- a/hicexplorer/hicPlotMatrix.py
+++ b/hicexplorer/hicPlotMatrix.py
@@ -468,7 +468,7 @@ def main(args=None):
 
         if args.log:
             mask = matrix == 0
-            matrix[mask] = matrix[mask == False].min()
+            matrix[mask] = matrix[mask == False].min()  # noqa
     #        matrix = -1 *  np.log(matrix)
             matrix = np.log(matrix)
 

--- a/hicexplorer/hicPlotMatrix.py
+++ b/hicexplorer/hicPlotMatrix.py
@@ -468,7 +468,7 @@ def main(args=None):
 
         if args.log:
             mask = matrix == 0
-            matrix[mask] = matrix[mask is False].min()
+            matrix[mask] = matrix[mask == False].min()
     #        matrix = -1 *  np.log(matrix)
             matrix = np.log(matrix)
 


### PR DESCRIPTION
```
matrix = np.array([[0, 1, 2, 0],[2, 3, 0, 1]])
mask = matrix == 0
```
It was the following:
```
> mask is False
False
```
which caused: 
```
IndexError: in the future, 0-d boolean arrays will be interpreted as a valid boolean index
```

What you probably want to have is:
```
> mask == False
array([[False,  True,  True, False],
       [ True,  True, False,  True]], dtype=bool)

```

//Edit:
FYI: This bug is in the master branch too.